### PR TITLE
Suggest regex fix for sphinxcontrib-manpage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requires = ['Sphinx>=0.9']
 setup(
 
     name='sphinxcontrib-manpage',
-    version='0.4',
+    version='0.5',
     url='https://github.com/tdi/sphinxcontrib-manpage',
     author='Dariusz Dwornikowski',
     author_email='dariusz.dwornikowski@cs.put.poznan.pl',

--- a/sphinxcontrib/manpage.py
+++ b/sphinxcontrib/manpage.py
@@ -32,7 +32,7 @@ def man_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """Link to an online man page issue.
     """
     app = inliner.document.settings.env.app
-    p = re.compile("([a-zA-Z0-9_\.-_]+)\((\d)\)")
+    p = re.compile("([a-zA-Z0-9_\.\-_]+)\((\d)\)")
     m = p.match(text)
 
     manpage_num = m.group(2)


### PR DESCRIPTION
Thanks for this module, I hope you are still able to update your package sometime, I suggest for you a simple fix. If I wish to use a manpage reference containing a hyphen, such as ````:linuxman:`pcap-savefile(5)````, we get a "Nonetype has no attribute ..." error,

because our regular expression failed to match the `-` in the phrase `pcap-savefile`. but you surely intended to! We just forgot to `\`escape it. You had a `-` in there, but of course, since `-` is special, we accidentally mean "from `.` through `_`", just as you earlier wrote "from `a` to `z`"

Anyway I bumped the version for you so I hope that helps. Enjoy and have a great day.