### PR TITLE
Allow manpage to use with sphinx -j auto or such

### DIFF
--- a/sphinxcontrib/manpage.py
+++ b/sphinxcontrib/manpage.py
@@ -47,5 +47,4 @@ def setup(app):
     logger.info('Initializing manpage plugin')
     app.add_role('linuxman', man_role)
     app.add_config_value('linux_man_url_regex', None, 'env')
-    return
-
+    return {'parallel_read_safe': True}


### PR DESCRIPTION
enable [parallel read safe](https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata).. unfortunately I could only get this to happen on travis-ci, but not locally, how strange, it precludes me from testing it locally, sorry! I can only suppose this works, feel free to let this languish until someone else can test for us :)

Here is the error from my Travis-CI build that got me down this path, https://travis-ci.org/jquast/blessed/jobs/644876200#L972 where ``sphinx-build -W -j 4`` is used, warning as errors, and parallel build, causing this warning to "fail the build".

Thanks always and again for your extension, I don't know why more folks aren't using this :)